### PR TITLE
Keep a running tally of how many SQL operations have been performed

### DIFF
--- a/effectful-opaleye/CHANGELOG.md
+++ b/effectful-opaleye/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- Ability to keep a running tally of the SQL operations that are performed by
+  the `Opaleye` effect in #4.
+
 ## [0.1.0.1] - 04.08.2025
 
 ### Changed

--- a/effectful-opaleye/CHANGELOG.md
+++ b/effectful-opaleye/CHANGELOG.md
@@ -28,5 +28,5 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - CI that builds and tests the packages for each version of GHC in the `tested-with` field.
 
 [unreleased]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.1...HEAD
-[0.1.0.1]: https://github.com/fpringle/effectful-postgresql/releases/tag/v0.1.0.1
+[0.1.0.1]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.0...v0.1.0.1
 [0.1.0.0]: https://github.com/fpringle/effectful-postgresql/releases/tag/v0.1.0.0

--- a/effectful-opaleye/effectful-opaleye.cabal
+++ b/effectful-opaleye/effectful-opaleye.cabal
@@ -43,6 +43,7 @@ common deps
     , postgresql-simple >= 0.7 && < 0.8
     , text >= 2.0 && < 2.2
     , containers >= 0.6 && < 0.8
+    , pretty >= 1.1.1.0 && < 1.2
 
 common extensions
   default-extensions:

--- a/effectful-opaleye/effectful-opaleye.cabal
+++ b/effectful-opaleye/effectful-opaleye.cabal
@@ -41,6 +41,8 @@ common deps
     , product-profunctors >= 0.9 && < 0.12
     , effectful-postgresql >= 0.1 && < 0.2
     , postgresql-simple >= 0.7 && < 0.8
+    , text >= 2.0 && < 2.2
+    , containers >= 0.6 && < 0.8
 
 common extensions
   default-extensions:
@@ -61,6 +63,7 @@ library
   exposed-modules:
       Effectful.Opaleye
       Effectful.Opaleye.Effect
+      Effectful.Opaleye.Count
   -- other-extensions:
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/effectful-opaleye/effectful-opaleye.cabal
+++ b/effectful-opaleye/effectful-opaleye.cabal
@@ -60,6 +60,7 @@ library
     , extensions
   exposed-modules:
       Effectful.Opaleye
+      Effectful.Opaleye.Effect
   -- other-extensions:
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/effectful-opaleye/src/Effectful/Opaleye.hs
+++ b/effectful-opaleye/src/Effectful/Opaleye.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Effectful.Opaleye
   ( -- * Effect
     Opaleye (..)
@@ -34,30 +32,10 @@ import Data.Profunctor.Product.Default
 import qualified Database.PostgreSQL.Simple as PSQL
 import Effectful
 import Effectful.Dispatch.Dynamic
+import Effectful.Opaleye.Effect
 import qualified Effectful.PostgreSQL.Connection as Conn
-import Effectful.TH
 import qualified Opaleye as O
 import qualified Opaleye.Internal.Inferrable as O
-
--- | A dynamic effect to perform @opaleye@ operations.
-data Opaleye :: Effect where
-  -- | Lifted 'O.RunSelectExplicit'.
-  RunSelectExplicit :: O.FromFields fields haskells -> O.Select fields -> Opaleye m [haskells]
-  -- | Lifted 'O.RunSelectFoldExplicit'.
-  RunSelectFoldExplicit ::
-    O.FromFields fields haskells ->
-    O.Select fields ->
-    b ->
-    (b -> haskells -> m b) ->
-    Opaleye m b
-  -- | Lifted 'O.RunInsert'.
-  RunInsert :: O.Insert haskells -> Opaleye m haskells
-  -- | Lifted 'O.RunDelete'.
-  RunDelete :: O.Delete haskells -> Opaleye m haskells
-  -- | Lifted 'O.RunUpdate'.
-  RunUpdate :: O.Update haskells -> Opaleye m haskells
-
-makeEffect ''Opaleye
 
 -- | Lifted 'O.runSelect'.
 runSelect ::

--- a/effectful-opaleye/src/Effectful/Opaleye.hs
+++ b/effectful-opaleye/src/Effectful/Opaleye.hs
@@ -31,6 +31,7 @@ module Effectful.Opaleye
     -- * Counting SQL operations
   , SQLOperationCounts (..)
   , withCounts
+  , printCounts
   )
 where
 

--- a/effectful-opaleye/src/Effectful/Opaleye/Count.hs
+++ b/effectful-opaleye/src/Effectful/Opaleye/Count.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Effectful.Opaleye.Count
+  ( -- * Counting SQL operations
+    SQLOperationCounts (..)
+  , opaleyeAddCounting
+  , withCounts
+  )
+where
+
+import Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Database.PostgreSQL.Simple.Types (QualifiedIdentifier (..))
+import Effectful
+import Effectful.Dispatch.Dynamic
+import Effectful.Opaleye.Effect
+import Effectful.State.Static.Shared
+import GHC.Generics
+import Numeric.Natural
+import qualified Opaleye as O
+import qualified Opaleye.Internal.PrimQuery as O (TableIdentifier (..))
+import qualified Opaleye.Internal.Table as O
+#if !MIN_VERSION_effectful_core(2,5,1)
+import Control.Monad (when)
+import Effectful.Dispatch.Static
+import Effectful.Internal.Env
+import Effectful.Internal.Monad
+import GHC.Stack
+#endif
+
+------------------------------------------------------------
+-- Tallying SQL operations
+
+{- | This tracks the number of SQL operations that have been performed in the
+'Opaleye' effect, along with which table it was performed on (where possible).
+
+@INSERT@, @DELETE@ and @UPDATE@ operations act on one table only, so we can tally the number
+of each that are performed on each table (indexed by a t'QualifiedIdentifier').
+@SELECT@ operations can act on multiple tables, so we just track the total number of selects.
+
+If required, t'SQLOperationCounts' can be constructed using 'Monoid' and combined using 'Semigroup'.
+
+We use non-negative 'Natural's as a tally since a negative number of operations makes no sense.
+-}
+data SQLOperationCounts = SQLOperationCounts
+  { sqlSelects :: Natural
+  , sqlInserts :: Map QualifiedIdentifier Natural
+  , sqlDeletes :: Map QualifiedIdentifier Natural
+  , sqlUpdates :: Map QualifiedIdentifier Natural
+  }
+  deriving (Show, Eq, Generic)
+
+instance Semigroup SQLOperationCounts where
+  SQLOperationCounts s1 i1 d1 u1 <> SQLOperationCounts s2 i2 d2 u2 =
+    SQLOperationCounts
+      (s1 + s2)
+      (i1 `addNatMaps` i2)
+      (d1 `addNatMaps` d2)
+      (u1 `addNatMaps` u2)
+    where
+      addNatMaps = Map.unionWith (+)
+
+instance Monoid SQLOperationCounts where
+  mempty = SQLOperationCounts 0 mempty mempty mempty
+
+{- | Add counting of SQL operations to the interpreter of an 'Opaleye' effect.
+Note that the effect itself is not actually interpreted. We do this using 'passthrough',
+which lets us perform some actions based on the 'Opaleye' constructor and then pass them
+through to the upstream handler (e.g. 'Effectful.Opaleye.runOpaleyeWithConnection' or
+'Effectful.Opaleye.runOpaleyeConnection'). See 'Effectful.Opaleye.runOpaleyeConnectionCounting'
+and 'Effectful.Opaleye.runOpaleyeWithConnectionCounting' for interpreters that do both.
+
+Note: this function should only be used once, otherwise the operations will be tallied
+more than once. Unless you're sure, it's probably better to use
+'Effectful.Opaleye.runOpaleyeConnectionCounting' or
+'Effectful.Opaleye.runOpaleyeWithConnectionCounting'.
+-}
+opaleyeAddCounting ::
+  forall a es.
+  (HasCallStack, State SQLOperationCounts :> es) =>
+  Eff (Opaleye : es) a ->
+  Eff (Opaleye : es) a
+opaleyeAddCounting = interpose $ \env op -> do
+  incrementOp op
+  passthrough env op
+  where
+    incrementOp :: forall b localEs. Opaleye (Eff localEs) b -> Eff (Opaleye : es) ()
+    incrementOp = \case
+      RunSelectExplicit {} -> incrementSelect
+      RunSelectFoldExplicit {} -> incrementSelect
+      RunInsert ins -> incrementInsert $ insertTableName ins
+      RunDelete del -> incrementDelete $ deleteTableName del
+      RunUpdate upd -> incrementUpdate $ updateTableName upd
+
+    incrementMap :: QualifiedIdentifier -> Map QualifiedIdentifier Natural -> Map QualifiedIdentifier Natural
+    incrementMap = Map.alter (Just . maybe 1 succ)
+
+    incrementSelect = modify $ \counts ->
+      counts {sqlSelects = succ $ sqlSelects counts}
+    incrementInsert name = modify $ \counts ->
+      counts {sqlInserts = incrementMap name $ sqlInserts counts}
+    incrementUpdate name = modify $ \counts ->
+      counts {sqlUpdates = incrementMap name $ sqlUpdates counts}
+    incrementDelete name = modify $ \counts ->
+      counts {sqlDeletes = incrementMap name $ sqlDeletes counts}
+
+-- | This allows us to count the number of SQL operations over the course of a sub-operation.
+withCounts ::
+  (State SQLOperationCounts :> es) =>
+  Eff es a ->
+  Eff es (SQLOperationCounts, a)
+withCounts eff = do
+  countsBefore <- get
+  res <- eff
+  countsAfter <- get
+  pure (countsAfter `subtractCounts` countsBefore, res)
+
+subtractNat :: Natural -> Natural -> Natural
+a `subtractNat` b = if a > b then a - b else 0
+
+subtractNatMaps :: (Ord k) => Map k Natural -> Map k Natural -> Map k Natural
+subtractNatMaps c1 c2 =
+  let f op count = Map.adjust (`subtractNat` count) op
+  in  Map.foldrWithKey f c1 c2
+
+subtractCounts :: SQLOperationCounts -> SQLOperationCounts -> SQLOperationCounts
+subtractCounts (SQLOperationCounts s1 i1 d1 u1) (SQLOperationCounts s2 i2 d2 u2) =
+  SQLOperationCounts
+    (s1 `subtractNat` s2)
+    (i1 `subtractNatMaps` i2)
+    (d1 `subtractNatMaps` d2)
+    (u1 `subtractNatMaps` u2)
+
+#if !MIN_VERSION_effectful_core(2,5,1)
+-- passthrough was only added in effectful-core-2.5.1, so if we don't have access to a version
+-- after that then we have to replicate it here
+passthrough ::
+  (HasCallStack, DispatchOf e ~ Dynamic, e :> es, e :> localEs) =>
+  LocalEnv localEs handlerEs ->
+  e (Eff localEs) a ->
+  Eff es a
+passthrough (LocalEnv les) op = unsafeEff $ \es -> do
+  Handler handlerEs handler <- getEnv es
+  when (envStorage les /= envStorage handlerEs) $ do
+    error "les and handlerEs point to different Storages"
+  unEff (withFrozenCallStack handler (LocalEnv les) op) handlerEs
+{-# NOINLINE passthrough #-}
+#endif
+
+------------------------------------------------------------
+-- Getting table identifiers from opaleye operations
+
+tableIdentifierToQualifiedIdentifier :: O.TableIdentifier -> QualifiedIdentifier
+tableIdentifierToQualifiedIdentifier (O.TableIdentifier mSchema table) =
+  QualifiedIdentifier (T.pack <$> mSchema) (T.pack table)
+
+insertTableName :: O.Insert haskells -> QualifiedIdentifier
+insertTableName (O.Insert table _ _ _) =
+  tableIdentifierToQualifiedIdentifier . O.tableIdentifier $ table
+
+updateTableName :: O.Update haskells -> QualifiedIdentifier
+updateTableName (O.Update table _ _ _) =
+  tableIdentifierToQualifiedIdentifier . O.tableIdentifier $ table
+
+deleteTableName :: O.Delete haskells -> QualifiedIdentifier
+deleteTableName (O.Delete table _ _) =
+  tableIdentifierToQualifiedIdentifier . O.tableIdentifier $ table

--- a/effectful-opaleye/src/Effectful/Opaleye/Effect.hs
+++ b/effectful-opaleye/src/Effectful/Opaleye/Effect.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Effectful.Opaleye.Effect
+  ( -- * Effect
+    Opaleye (..)
+
+    -- ** Effectful functions
+  , runSelectExplicit
+  , runSelectFoldExplicit
+  , runInsert
+  , runDelete
+  , runUpdate
+  )
+where
+
+import Effectful
+import Effectful.TH
+import qualified Opaleye as O
+
+-- | A dynamic effect to perform @opaleye@ operations.
+data Opaleye :: Effect where
+  -- | Lifted 'O.RunSelectExplicit'.
+  RunSelectExplicit :: O.FromFields fields haskells -> O.Select fields -> Opaleye m [haskells]
+  -- | Lifted 'O.RunSelectFoldExplicit'.
+  RunSelectFoldExplicit ::
+    O.FromFields fields haskells ->
+    O.Select fields ->
+    b ->
+    (b -> haskells -> m b) ->
+    Opaleye m b
+  -- | Lifted 'O.RunInsert'.
+  RunInsert :: O.Insert haskells -> Opaleye m haskells
+  -- | Lifted 'O.RunDelete'.
+  RunDelete :: O.Delete haskells -> Opaleye m haskells
+  -- | Lifted 'O.RunUpdate'.
+  RunUpdate :: O.Update haskells -> Opaleye m haskells
+
+makeEffect ''Opaleye

--- a/effectful-postgresql/CHANGELOG.md
+++ b/effectful-postgresql/CHANGELOG.md
@@ -23,5 +23,5 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - CI that builds and tests the packages for each version of GHC in the `tested-with` field.
 
 [unreleased]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.1...HEAD
-[0.1.0.1]: https://github.com/fpringle/effectful-postgresql/releases/tag/v0.1.0.1
+[0.1.0.1]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.0...v0.1.0.1
 [0.1.0.0]: https://github.com/fpringle/effectful-postgresql/releases/tag/v0.1.0.0


### PR DESCRIPTION
Thanks to our dynamic `Opaleye` effect, we can write an alternative interpreter which, as well as performing SQL operations as before, will also keep a tally of the number of `SELECT`s, `INSERT`s etc that have been performed. This is really useful for debugging.

The intended use-case is a sort of bench mark that runs several `Opaleye` operations for different "sizes", counts the SQL operations, and prints the tallies to the console. This lets us detect if some implementations are ineffecient. For example, for a typical simple read operation e.g. `getUserTransactions :: [UserId] -> Eff es [[Transaction]]`, the number of `SELECT`s should not depend on the _number_ of `User`s or their `Transactions`s. We would expect the number of `SELECT`s to remain basically constant (`O(1)`), while the execution time might grow linearly (`O(u * t)`). If we notice that the number of `SELECT`s is actually growing linearly, clearly there's an inefficiency in our query design.

I've already used this in a real-world project, and it was remarkably useful to detect inefficient queries.