### PR TITLE
Release `effectful-opaleye:0.1.1.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ See the package READMEs for more detail:
 
 - [effectful-postgresql](./effectful-postgresql#readme)
 - [effectful-opaleye](./effectful-opaleye#readme)
+
+## Note to self
+
+The documentation uploaded to Hackage should be built using `effectful-th >= 1.0.0.3`. This will take the haddocks of the `Opaleye` constructors and use them as the haddocks of the corresponding TH-generated functions.

--- a/effectful-opaleye/CHANGELOG.md
+++ b/effectful-opaleye/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+## [0.1.1.0] - 15.08.2025
+
 ### Added
 
 - Ability to keep a running tally of the SQL operations that are performed by
@@ -27,6 +29,7 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 - Reasonably detailed READMEs.
 - CI that builds and tests the packages for each version of GHC in the `tested-with` field.
 
-[unreleased]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.1...HEAD
+[unreleased]: https://github.com/fpringle/effectful-postgresql/compare/effectful-opaleye-0.1.1.0...HEAD
+[0.1.1.0]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.1...effectful-opaleye-0.1.1.0
 [0.1.0.1]: https://github.com/fpringle/effectful-postgresql/compare/v0.1.0.0...v0.1.0.1
 [0.1.0.0]: https://github.com/fpringle/effectful-postgresql/releases/tag/v0.1.0.0

--- a/effectful-opaleye/effectful-opaleye.cabal
+++ b/effectful-opaleye/effectful-opaleye.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               effectful-opaleye
-version:            0.1.0.1
+version:            0.1.1.0
 synopsis:
   effectful support for high-level PostgreSQL operations via Opaleye.
 description:


### PR DESCRIPTION
Note: the documentation uploaded to Hackage (currently [here](https://hackage.haskell.org/package/effectful-opaleye-0.1.1.0/candidate), soon to be [here](https://hackage.haskell.org/package/effectful-opaleye-0.1.1.0)) should be built using `effectful-th >= 1.0.0.3`. This will take the haddocks of the `Opaleye` constructors and use them as the haddocks of the corresponding TH-generated functions.
