### PR TITLE
Add OpenTelemetry instrumentation support via enable-otel flag

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,12 @@ documentation: False
 
 package *
   documentation: False
+
+-- Use latest hs-opentelemetry from GitHub for GHC 9.12 support
+-- (Hackage version is outdated)
+source-repository-package
+  type: git
+  location: https://github.com/iand675/hs-opentelemetry.git
+  tag: 841a8e191fba3f2c76f6e6fa10d26b644856b7ee
+  subdir: api
+          instrumentation/postgresql-simple

--- a/effectful-postgresql/CHANGELOG.md
+++ b/effectful-postgresql/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Haskell Package Versioning Policy](https://pvp.hask
 
 ## [Unreleased]
 
+### Added
+
+- OpenTelemetry instrumentation support via `enable-otel` flag (transparent, no code changes required)
+
 ## [0.1.0.1] - 04.08.2025
 
 ### Changed

--- a/effectful-postgresql/README.md
+++ b/effectful-postgresql/README.md
@@ -82,3 +82,14 @@ usingConnectionPool = do
   pool <- P.newPool poolCfg
   runEff . EP.runWithconnectionPool pool $ insertAndListCarefully
 ```
+
+## OpenTelemetry Instrumentation
+
+For applications using OpenTelemetry for distributed tracing, enable the `enable-otel` flag:
+
+```cabal
+dependencies:
+  - effectful-postgresql +enable-otel
+```
+
+All database operations will automatically create OpenTelemetry spans with database attributes. No code changes required - the same `Effectful.PostgreSQL` module transparently uses instrumented functions when the flag is enabled.

--- a/effectful-postgresql/effectful-postgresql.cabal
+++ b/effectful-postgresql/effectful-postgresql.cabal
@@ -36,11 +36,20 @@ flag enable-pool
   default: True
   manual: False
 
+flag enable-otel
+  description: Enable OpenTelemetry instrumentation support using
+               hs-opentelemetry-instrumentation-postgresql-simple.
+  default: False
+  manual: True
+
 common warnings
   ghc-options: -Wall -Wno-unused-do-bind -Wunused-packages
 
   if flag(enable-pool)
     cpp-options: -DPOOL
+
+  if flag(enable-otel)
+    cpp-options: -DOTEL
 
 common deps
   build-depends:
@@ -52,6 +61,10 @@ common deps
   if flag(enable-pool)
     build-depends:
       , unliftio-pool >= 0.4.1 && < 0.5
+
+  if flag(enable-otel)
+    build-depends:
+      , hs-opentelemetry-instrumentation-postgresql-simple >= 0.2 && < 0.4
 
 common extensions
   default-extensions:

--- a/effectful-postgresql/src/Effectful/PostgreSQL.hs
+++ b/effectful-postgresql/src/Effectful/PostgreSQL.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
 
 module Effectful.PostgreSQL
   ( -- * Effect
@@ -51,7 +52,11 @@ module Effectful.PostgreSQL
 where
 
 import Data.Int (Int64)
+#if OTEL
+import qualified "hs-opentelemetry-instrumentation-postgresql-simple" OpenTelemetry.Instrumentation.PostgresqlSimple as PSQL
+#else
 import qualified Database.PostgreSQL.Simple as PSQL
+#endif
 import qualified Database.PostgreSQL.Simple.FromRow as PSQL
 import Effectful
 import Effectful.PostgreSQL.Connection as Conn
@@ -212,7 +217,12 @@ forEach ::
   Eff es ()
 forEach q row forR =
   unliftWithConn $ \conn unlift ->
+#if OTEL
+    -- Workaround for bug in hs-opentelemetry-instrumentation-postgresql-simple
+    PSQL.forEachWith PSQL.fromRow conn q row (unlift . forR)
+#else
     PSQL.forEach conn q row (unlift . forR)
+#endif
 
 -- | Lifted 'PSQL.forEach_'.
 forEach_ ::


### PR DESCRIPTION
When the flag is enabled, database operations automatically create OpenTelemetry spans using hs-opentelemetry-instrumentation-postgresql-simple. No code changes required. The same Effectful.PostgreSQL module transparently uses instrumented functions.

Includes workaround for forEach bug in the upstream instrumentation package.